### PR TITLE
[v2.20.1-redpanda] replace crypto/md5 with github.com/cloudflare/cfssl/scan/crypto/md5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module github.com/hamba/avro/v2
 go 1.20
 
 require (
+	github.com/cloudflare/cfssl v1.6.5
 	github.com/ettle/strcase v0.2.0
 	github.com/golang/snappy v0.0.4
 	github.com/json-iterator/go v1.1.12
 	github.com/klauspost/compress v1.17.7
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/modern-go/reflect2 v1.0.2
-	github.com/stretchr/testify v1.7.1
+	github.com/stretchr/testify v1.8.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cloudflare/cfssl v1.6.5 h1:46zpNkm6dlNkMZH/wMW22ejih6gIaJbzL2du6vD7ZeI=
+github.com/cloudflare/cfssl v1.6.5/go.mod h1:Bk1si7sq8h2+yVEDrFJiz3d7Aw+pfjjJSZVaD+Taky4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -21,10 +23,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/protocol.go
+++ b/protocol.go
@@ -1,11 +1,12 @@
 package avro
 
 import (
-	"crypto/md5"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
+
+	"github.com/cloudflare/cfssl/scan/crypto/md5"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/mitchellh/mapstructure"

--- a/protocol.go
+++ b/protocol.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/cloudflare/cfssl/scan/crypto/md5"
-
 	jsoniter "github.com/json-iterator/go"
 	"github.com/mitchellh/mapstructure"
 )

--- a/schema.go
+++ b/schema.go
@@ -2,7 +2,6 @@ package avro
 
 import (
 	"bytes"
-	"crypto/md5"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/cloudflare/cfssl/scan/crypto/md5"
 
 	"github.com/hamba/avro/v2/pkg/crc64"
 	jsoniter "github.com/json-iterator/go"

--- a/schema.go
+++ b/schema.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 
 	"github.com/cloudflare/cfssl/scan/crypto/md5"
-
 	"github.com/hamba/avro/v2/pkg/crc64"
 	jsoniter "github.com/json-iterator/go"
 )


### PR DESCRIPTION
related issue https://redpandadata.atlassian.net/browse/PESDLC-1040

This PR replaces standard go library `crypto/md5` with https://pkg.go.dev/github.com/cloudflare/cfssl@v1.6.5/scan/crypto/md5

So this can be compiled with microsoft golang compiler without panics.

The project that adds this to `go.mod` needs to also add a `replace` directive:
```
replace github.com/hamba/avro/v2 => github.com/redpanda-data/go-avro/v2 v2.20.1-redpanda
```
and then run:
```console
go mod tidy
```
to update `go.sum`.