### PR TITLE
Bump Go toolchain to 1.26.3 to address Snyk findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hamba/avro/v2
 
-go 1.26.3
+go 1.20
+
+toolchain go1.26.3
 
 require (
 	github.com/ettle/strcase v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hamba/avro/v2
 
-go 1.20
+go 1.26.3
 
 require (
 	github.com/ettle/strcase v0.2.0


### PR DESCRIPTION
## Summary

Bumps the Go directive in go.mod from 1.20 to 1.26.3 to address Snyk HIGH stdlib findings:

- CVE-2026-33811 Double Free in std/net (GO-2026-4981)
- CVE-2026-39836 Uncaught Exception in std/net (GO-2026-4971)
- CVE-2026-33814 Infinite loop in std/net/http (GO-2026-4918)

All three are fixed by Go 1.26.3.

## Test plan

- [ ] CI passes
- [ ] Snyk re-scan no longer reports the listed CVEs